### PR TITLE
Copy the PDF

### DIFF
--- a/config/gulp/copy.js
+++ b/config/gulp/copy.js
@@ -2,9 +2,6 @@ import gulp from 'gulp';
 
 export default () => {
     return gulp
-        .src([
-            'source/*.ico',
-            'source/*.txt',
-        ])
+        .src(['source/*.{ico,icns,pdf,txt}'])
         .pipe(gulp.dest('public'));
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "version": "1.0.0",
   "description": "The website of Rebecca Bosshart, author, journalist, teacher, redhead.",
   "scripts": {
+    "clean:public": "rm -rf public/",
+    "clean:deploy": "rm -rf deploy/",
     "build": "gulp",
-    "prebuild": "rm -rf public/ deploy/",
+    "prebuild": "npm run clean:public",
     "deploy": "gulp deploy",
+    "predeploy": "npm run clean:deploy && npm run build",
     "test": "echo \"Error: no test specified\" && exit 0"
   },
   "repository": {


### PR DESCRIPTION
This adds a little bit of config to the copy task to make it also copy any PDFs (namely Becky's CV) in the assets folder over to the built public directory.
#### How to test
1. Checkout this branch with `git checkout mysterycommand/copy-pdf`
2. Make sure your dependencies are up to date with `rm -rf node_modules/ && npm install`
3. Run the build command with `npm run build`
4. Verify that the PDF is copied into the `public` folder (generated by the build commend) at `/public/CVbosshart_bosshart.pdf`
5. Double check that the PDF is downloadable when you open `/public/index.html` in your browser.

As an extra testing measure go ahead and check that the staging site (http://beckybosshart.com/staging/21/) is updated and that the PDF is downloadable from there as expected.
